### PR TITLE
Make binary install paths absolute to trigger CF relocatable patching.

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,9 +1,9 @@
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.12'
+- '2.17'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,7 +20,7 @@ CCFLAGS="${CXXFLAGS} ${LDFLAGS}"
 # fi
 
 echo "make all CC=${CC} CCFLAGS=${CCFLAGS}"
-make all CC=${CC} CCFLAGS=${CCFLAGS}
+make all CC=${CC} CCFLAGS="${CCFLAGS}"
 # make all CC=${CC} CCFLAGS=${CCFLAGS} LIB=${PREFIX}/lib
 
 # copy dynamic libraries into standard location

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,28 +3,35 @@
 set -e
 
 # Put conda-build compiler flags into a variable already used in the
-# Makefile by overriding it, including some of what it included originally.
-# Hopefully, this will pass conda-build's @rpath and make the library
-# relocatable.
-
-# CCFLAGS="${CFLAGS} ${CXXFLAGS} ${LDFLAGS} -m64 -O3"
-# CCFLAGS="${CXXFLAGS} ${LDFLAGS} -m64 -O3"
+# Makefile by overriding it. Hopefully, this will pass conda-build's @rpath and
+# make the library relocatable.
 CCFLAGS="${CXXFLAGS} ${LDFLAGS}"
 
+# install_name is where the library thinks it is.
 # if [[ `uname` == 'Linux' ]]; then
-#     # g++
-#     CCFLAGS="${CCFLAGS} -DLinux"
+#     CCFLAGS="${CCFLAGS} -Wl,-install_name,@rpath/libgeotesscpp.${SHLIB_EXT}"
 # else
-#     # Apple Clang
-#     CCFLAGS="${CCFLAGS} -DDarwin"
+#     CCFLAGS="${CCFLAGS} -Wl,-install_name,@rpath/libgeotesscpp.${SHLIB_EXT}"
 # fi
 
-echo "make all CC=${CC} CCFLAGS=${CCFLAGS}"
-make all CC=${CC} CCFLAGS="${CCFLAGS}"
-# make all CC=${CC} CCFLAGS=${CCFLAGS} LIB=${PREFIX}/lib
+
+# LIB is the output location of the library, which also tells linking programs
+# where to look for it.  $PREFIX is an absolute path on the build machine that
+# should be overwritten by patchelf or install_name_tool to make it relocatable.
+LIB=$PREFIX/lib
+# echo "make libraries CC=${CC} LIB=${LIB} CCFLAGS=${CCFLAGS}"
+make libraries CC=${CC} LIB=${LIB} CCFLAGS="${CCFLAGS}"
 
 # copy dynamic libraries into standard location
-cp lib/* $PREFIX/lib/
+# This should be done already if LIB is set properly
+# cp lib/* $PREFIX/lib/
+
+# See if the absolute paths were properly patched.
+if [[ `uname` == 'Linux' ]]; then
+    readelf -d -r $PREFIX/lib/libgeotess*
+else
+    objdump -p $PREFIX/lib/libgeotess*
+fi
 
 # copy headers into standard location
 mkdir -p $PREFIX/include/geotesscpp

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,6 +18,9 @@ else
     CCFLAGS="${CCFLAGS} -DDarwin"
 fi
 
+echo "CC ${CC}"
+echo "CCFLAGS  ${CCFLAGS}"
+
 make all CC=${CC} CCFLAGS=${CCFLAGS}
 # make all CC=${CC} CCFLAGS=${CCFLAGS} LIB=${PREFIX}/lib
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,9 +2,10 @@
 
 set -e
 
-# Put conda-build compiler flags into a variable used in the Makefile by 
-# overwriting it, including some of what it included originally.
-# Hopefully, this will pass @rpath and make the library relocatable.
+# Put conda-build compiler flags into a variable already used in the
+# Makefile by overriding it, including some of what it included originally.
+# Hopefully, this will pass conda-build's @rpath and make the library
+# relocatable.
 
 # CCFLAGS="${CFLAGS} ${CXXFLAGS} ${LDFLAGS} -m64 -O3"
 CCFLAGS="${CXXFLAGS} ${LDFLAGS} -m64 -O3"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,7 +2,23 @@
 
 set -e
 
-make all CC=${CC}
+# Put conda-build compiler flags into a variable used in the Makefile by 
+# overwriting it, including some of what it included originally.
+# Hopefully, this will pass @rpath and make the library relocatable.
+
+# CCFLAGS="${CFLAGS} ${CXXFLAGS} ${LDFLAGS} -m64 -O3"
+CCFLAGS="${CXXFLAGS} ${LDFLAGS} -m64 -O3"
+
+if [[ `uname` == 'Linux' ]]; then
+    # g++
+    CCFLAGS="${CCFLAGS} -DLinux"
+else
+    # Apple Clang
+    CCFLAGS="${CCFLAGS} -DDarwin"
+fi
+
+make all CC=${CC} CCFLAGS=${CCFLAGS}
+# make all CC=${CC} CCFLAGS=${CCFLAGS} LIB=${PREFIX}/lib
 
 # copy dynamic libraries into standard location
 cp lib/* $PREFIX/lib/

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,6 +10,6 @@ cp lib/* $PREFIX/lib/
 # copy headers into standard location
 mkdir -p $PREFIX/include/geotesscpp
 cp GeoTessCPP/include/* $PREFIX/include/geotesscpp
-cp GeoTessCPP/GeoTessCPPExamples/include/AK135Model.h $PREFIX/include/geotesscpp
+cp GeoTessCPPExamples/include/AK135Model.h $PREFIX/include/geotesscpp
 cp GeoTessAmplitudeCPP/include/* $PREFIX/include/geotesscpp
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,5 +10,6 @@ cp lib/* $PREFIX/lib/
 # copy headers into standard location
 mkdir -p $PREFIX/include/geotesscpp
 cp GeoTessCPP/include/* $PREFIX/include/geotesscpp
+cp GeoTessCPP/GeoTessCPPExamples/include/AK135Model.h $PREFIX/include/geotesscpp
 cp GeoTessAmplitudeCPP/include/* $PREFIX/include/geotesscpp
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,9 +18,7 @@ CCFLAGS="${CXXFLAGS} ${LDFLAGS}"
 # LIB is the output location of the library, which also tells linking programs
 # where to look for it.  $PREFIX is an absolute path on the build machine that
 # should be overwritten by patchelf or install_name_tool to make it relocatable.
-LIB=$PREFIX/lib
-# echo "make libraries CC=${CC} LIB=${LIB} CCFLAGS=${CCFLAGS}"
-make libraries CC=${CC} LIB=${LIB} CCFLAGS="${CCFLAGS}"
+make libraries CC=${CC} LIB=${PREFIX}/lib CCFLAGS="${CCFLAGS}"
 
 # copy dynamic libraries into standard location
 # This should be done already if LIB is set properly

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,9 +18,7 @@ else
     CCFLAGS="${CCFLAGS} -DDarwin"
 fi
 
-echo "CC ${CC}"
-echo "CCFLAGS  ${CCFLAGS}"
-
+echo "make all CC=${CC} CCFLAGS=${CCFLAGS}"
 make all CC=${CC} CCFLAGS=${CCFLAGS}
 # make all CC=${CC} CCFLAGS=${CCFLAGS} LIB=${PREFIX}/lib
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,15 +8,16 @@ set -e
 # relocatable.
 
 # CCFLAGS="${CFLAGS} ${CXXFLAGS} ${LDFLAGS} -m64 -O3"
-CCFLAGS="${CXXFLAGS} ${LDFLAGS} -m64 -O3"
+# CCFLAGS="${CXXFLAGS} ${LDFLAGS} -m64 -O3"
+CCFLAGS="${CXXFLAGS} ${LDFLAGS}"
 
-if [[ `uname` == 'Linux' ]]; then
-    # g++
-    CCFLAGS="${CCFLAGS} -DLinux"
-else
-    # Apple Clang
-    CCFLAGS="${CCFLAGS} -DDarwin"
-fi
+# if [[ `uname` == 'Linux' ]]; then
+#     # g++
+#     CCFLAGS="${CCFLAGS} -DLinux"
+# else
+#     # Apple Clang
+#     CCFLAGS="${CCFLAGS} -DDarwin"
+# fi
 
 echo "make all CC=${CC} CCFLAGS=${CCFLAGS}"
 make all CC=${CC} CCFLAGS=${CCFLAGS}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 64a50ea5c40609a7e965a2c33a4aacfff03ffa5de5b94d81bf9c6fab13ef7c59
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ test:
     - objdump -p $PREFIX/lib/libgeotesscpp$SHLIB_EXT  # [osx]
     - objdump -p $PREFIX/lib/libgeotessamplitudecpp$SHLIB_EXT  # [osx]
     - readelf -d -r $PREFIX/lib/libgeotesscpp$SHLIB_EXT  # [linux]
-    - readelf -d -r $PREFIX/lib/libgeotessamplitudecpp$SHLIB_EXT # [linux]
+    - readelf -d -r $PREFIX/lib/libgeotessamplitudecpp$SHLIB_EXT  # [linux]
 
 about:
   home: https://www.sandia.gov/geotess/ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 64a50ea5c40609a7e965a2c33a4aacfff03ffa5de5b94d81bf9c6fab13ef7c59
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 64a50ea5c40609a7e965a2c33a4aacfff03ffa5de5b94d81bf9c6fab13ef7c59
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ test:
     - test -f $PREFIX/lib/libgeotessamplitudecpp$SHLIB_EXT  # [unix]
     - objdump -p $PREFIX/lib/libgeotesscpp$SHLIB_EXT  # [osx]
     - objdump -p $PREFIX/lib/libgeotessamplitudecpp$SHLIB_EXT  # [osx]
-    - readelf -d -r $PREFIX/lib/libgeotesscpp$SHLIB_EXT # [linux]
+    - readelf -d -r $PREFIX/lib/libgeotesscpp$SHLIB_EXT  # [linux]
     - readelf -d -r $PREFIX/lib/libgeotessamplitudecpp$SHLIB_EXT # [linux]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,9 +20,15 @@ requirements:
     - make
 
 test:
+  requires:
+    - binutils
   commands:
     - test -f $PREFIX/lib/libgeotesscpp$SHLIB_EXT  # [unix]
     - test -f $PREFIX/lib/libgeotessamplitudecpp$SHLIB_EXT  # [unix]
+    - objdump -p $PREFIX/lib/libgeotesscpp$SHLIB_EXT  # [osx]
+    - objdump -p $PREFIX/lib/libgeotessamplitudecpp$SHLIB_EXT  # [osx]
+    - readelf -d -r $PREFIX/lib/libgeotesscpp$SHLIB_EXT # [linux]
+    - readelf -d -r $PREFIX/lib/libgeotessamplitudecpp$SHLIB_EXT # [linux]
 
 about:
   home: https://www.sandia.gov/geotess/ 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [] ~~Reset the build number to `0` (if the version changed)~~
* [] ~~[Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)~~
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Trying to add `@rpath` or `$ORIGIN` to the dynamic library paths during linking/runtime is tricky.  This PR makes install paths (and therefore `-install_name`) absolute, which should trigger the conda-forge patching that makes binaries relocatable (i.e. adding `@rpath`/`$ORIGIN`). Also adds some print debugging to the shared libraries to help diagnose this PR.